### PR TITLE
Fix build errors on latest Kernel shipped by Arch (6.12.6)

### DIFF
--- a/install.cirrus.driver.sh
+++ b/install.cirrus.driver.sh
@@ -56,8 +56,9 @@ mv $hda_dir/patch_cirrus.c $hda_dir/patch_cirrus.c.orig
 cp $patch_dir/Makefile $patch_dir/patch_cirrus.c $patch_dir/patch_cirrus_a1534_setup.h $patch_dir/patch_cirrus_a1534_pcm.h $hda_dir/
 
 # if kernel version is >= 6.12 then change
-# timespec64 to timespec
-# ktime_get_real_ts64 to getnstimeofday
+# snd_pci_quirk to hda_quirk
+# SND_PCI_QUIRK to HDA_CODEC_QUIRK
+# but leave alone SND_PCI_QUIRK_VENDOR
 
 if (( major_version > 6 || (major_version == 6 && minor_version >= 12) )); then
    sed -i 's/snd_pci_quirk/hda_quirk/' $hda_dir/patch_cirrus.c

--- a/install.cirrus.driver.sh
+++ b/install.cirrus.driver.sh
@@ -55,6 +55,15 @@ mv $hda_dir/Makefile $hda_dir/Makefile.orig
 mv $hda_dir/patch_cirrus.c $hda_dir/patch_cirrus.c.orig
 cp $patch_dir/Makefile $patch_dir/patch_cirrus.c $patch_dir/patch_cirrus_a1534_setup.h $patch_dir/patch_cirrus_a1534_pcm.h $hda_dir/
 
+# if kernel version is >= 6.12 then change
+# timespec64 to timespec
+# ktime_get_real_ts64 to getnstimeofday
+
+if (( major_version > 6 || (major_version == 6 && minor_version >= 12) )); then
+   sed -i 's/snd_pci_quirk/hda_quirk/' $hda_dir/patch_cirrus.c
+   sed -i 's/SND_PCI_QUIRK\b/HDA_CODEC_QUIRK/' $hda_dir/patch_cirrus.c
+fi
+
 # if kernel version is < 5.6 then change
 # timespec64 to timespec
 # ktime_get_real_ts64 to getnstimeofday

--- a/patch_cirrus/patch_cirrus.c
+++ b/patch_cirrus/patch_cirrus.c
@@ -396,21 +396,21 @@ static const struct hda_model_fixup cs420x_models[] = {
 	{}
 };
 
-static const struct snd_pci_quirk cs420x_fixup_tbl[] = {
-	SND_PCI_QUIRK(0x10de, 0x0ac0, "MacBookPro 5,3", CS420X_MBP53),
-	SND_PCI_QUIRK(0x10de, 0x0d94, "MacBookAir 3,1(2)", CS420X_MBP55),
-	SND_PCI_QUIRK(0x10de, 0xcb79, "MacBookPro 5,5", CS420X_MBP55),
-	SND_PCI_QUIRK(0x10de, 0xcb89, "MacBookPro 7,1", CS420X_MBP55),
+static const struct hda_quirk cs420x_fixup_tbl[] = {
+	HDA_CODEC_QUIRK(0x10de, 0x0ac0, "MacBookPro 5,3", CS420X_MBP53),
+	HDA_CODEC_QUIRK(0x10de, 0x0d94, "MacBookAir 3,1(2)", CS420X_MBP55),
+	HDA_CODEC_QUIRK(0x10de, 0xcb79, "MacBookPro 5,5", CS420X_MBP55),
+	HDA_CODEC_QUIRK(0x10de, 0xcb89, "MacBookPro 7,1", CS420X_MBP55),
 	/* this conflicts with too many other models */
-	/*SND_PCI_QUIRK(0x8086, 0x7270, "IMac 27 Inch", CS420X_IMAC27),*/
+	/*HDA_CODEC_QUIRK(0x8086, 0x7270, "IMac 27 Inch", CS420X_IMAC27),*/
 
 	/* codec SSID */
-	SND_PCI_QUIRK(0x106b, 0x0600, "iMac 14,1", CS420X_IMAC27_122),
-	SND_PCI_QUIRK(0x106b, 0x1c00, "MacBookPro 8,1", CS420X_MBP81),
-	SND_PCI_QUIRK(0x106b, 0x2000, "iMac 12,2", CS420X_IMAC27_122),
-	SND_PCI_QUIRK(0x106b, 0x2800, "MacBookPro 10,1", CS420X_MBP101),
-	SND_PCI_QUIRK(0x106b, 0x5600, "MacBookAir 5,2", CS420X_MBP81),
-	SND_PCI_QUIRK(0x106b, 0x5b00, "MacBookAir 4,2", CS420X_MBA42),
+	HDA_CODEC_QUIRK(0x106b, 0x0600, "iMac 14,1", CS420X_IMAC27_122),
+	HDA_CODEC_QUIRK(0x106b, 0x1c00, "MacBookPro 8,1", CS420X_MBP81),
+	HDA_CODEC_QUIRK(0x106b, 0x2000, "iMac 12,2", CS420X_IMAC27_122),
+	HDA_CODEC_QUIRK(0x106b, 0x2800, "MacBookPro 10,1", CS420X_MBP101),
+	HDA_CODEC_QUIRK(0x106b, 0x5600, "MacBookAir 5,2", CS420X_MBP81),
+	HDA_CODEC_QUIRK(0x106b, 0x5b00, "MacBookAir 4,2", CS420X_MBA42),
 	SND_PCI_QUIRK_VENDOR(0x106b, "Apple", CS420X_APPLE),
 	{} /* terminator */
 };
@@ -644,18 +644,18 @@ static const struct hda_model_fixup cs4208_models[] = {
 	{}
 };
 
-static const struct snd_pci_quirk cs4208_fixup_tbl[] = {
+static const struct hda_quirk cs4208_fixup_tbl[] = {
 	SND_PCI_QUIRK_VENDOR(0x106b, "Apple", CS4208_MAC_AUTO),
 	{} /* terminator */
 };
 
 /* codec SSID matching */
-static const struct snd_pci_quirk cs4208_mac_fixup_tbl[] = {
-	SND_PCI_QUIRK(0x106b, 0x5e00, "MacBookPro 11,2", CS4208_MBP11),
-	SND_PCI_QUIRK(0x106b, 0x6c00, "MacMini 7,1", CS4208_MACMINI),
-	SND_PCI_QUIRK(0x106b, 0x7100, "MacBookAir 6,1", CS4208_MBA6),
-	SND_PCI_QUIRK(0x106b, 0x7200, "MacBookAir 6,2", CS4208_MBA6),
-	SND_PCI_QUIRK(0x106b, 0x7b00, "MacBookPro 12,1", CS4208_MBP11),
+static const struct hda_quirk cs4208_mac_fixup_tbl[] = {
+	HDA_CODEC_QUIRK(0x106b, 0x5e00, "MacBookPro 11,2", CS4208_MBP11),
+	HDA_CODEC_QUIRK(0x106b, 0x6c00, "MacMini 7,1", CS4208_MACMINI),
+	HDA_CODEC_QUIRK(0x106b, 0x7100, "MacBookAir 6,1", CS4208_MBA6),
+	HDA_CODEC_QUIRK(0x106b, 0x7200, "MacBookAir 6,2", CS4208_MBA6),
+	HDA_CODEC_QUIRK(0x106b, 0x7b00, "MacBookPro 12,1", CS4208_MBP11),
 	{} /* terminator */
 };
 
@@ -834,9 +834,9 @@ static const struct hda_model_fixup cs421x_models[] = {
 	{}
 };
 
-static const struct snd_pci_quirk cs421x_fixup_tbl[] = {
+static const struct hda_quirk cs421x_fixup_tbl[] = {
 	/* Test Intel board + CDB2410  */
-	SND_PCI_QUIRK(0x8086, 0x5001, "DP45SG/CDB4210", CS421X_CDB4210),
+	HDA_CODEC_QUIRK(0x8086, 0x5001, "DP45SG/CDB4210", CS421X_CDB4210),
 	{} /* terminator */
 };
 

--- a/patch_cirrus/patch_cirrus.c
+++ b/patch_cirrus/patch_cirrus.c
@@ -396,21 +396,21 @@ static const struct hda_model_fixup cs420x_models[] = {
 	{}
 };
 
-static const struct hda_quirk cs420x_fixup_tbl[] = {
-	HDA_CODEC_QUIRK(0x10de, 0x0ac0, "MacBookPro 5,3", CS420X_MBP53),
-	HDA_CODEC_QUIRK(0x10de, 0x0d94, "MacBookAir 3,1(2)", CS420X_MBP55),
-	HDA_CODEC_QUIRK(0x10de, 0xcb79, "MacBookPro 5,5", CS420X_MBP55),
-	HDA_CODEC_QUIRK(0x10de, 0xcb89, "MacBookPro 7,1", CS420X_MBP55),
+static const struct snd_pci_quirk cs420x_fixup_tbl[] = {
+	SND_PCI_QUIRK(0x10de, 0x0ac0, "MacBookPro 5,3", CS420X_MBP53),
+	SND_PCI_QUIRK(0x10de, 0x0d94, "MacBookAir 3,1(2)", CS420X_MBP55),
+	SND_PCI_QUIRK(0x10de, 0xcb79, "MacBookPro 5,5", CS420X_MBP55),
+	SND_PCI_QUIRK(0x10de, 0xcb89, "MacBookPro 7,1", CS420X_MBP55),
 	/* this conflicts with too many other models */
-	/*HDA_CODEC_QUIRK(0x8086, 0x7270, "IMac 27 Inch", CS420X_IMAC27),*/
+	/*SND_PCI_QUIRK(0x8086, 0x7270, "IMac 27 Inch", CS420X_IMAC27),*/
 
 	/* codec SSID */
-	HDA_CODEC_QUIRK(0x106b, 0x0600, "iMac 14,1", CS420X_IMAC27_122),
-	HDA_CODEC_QUIRK(0x106b, 0x1c00, "MacBookPro 8,1", CS420X_MBP81),
-	HDA_CODEC_QUIRK(0x106b, 0x2000, "iMac 12,2", CS420X_IMAC27_122),
-	HDA_CODEC_QUIRK(0x106b, 0x2800, "MacBookPro 10,1", CS420X_MBP101),
-	HDA_CODEC_QUIRK(0x106b, 0x5600, "MacBookAir 5,2", CS420X_MBP81),
-	HDA_CODEC_QUIRK(0x106b, 0x5b00, "MacBookAir 4,2", CS420X_MBA42),
+	SND_PCI_QUIRK(0x106b, 0x0600, "iMac 14,1", CS420X_IMAC27_122),
+	SND_PCI_QUIRK(0x106b, 0x1c00, "MacBookPro 8,1", CS420X_MBP81),
+	SND_PCI_QUIRK(0x106b, 0x2000, "iMac 12,2", CS420X_IMAC27_122),
+	SND_PCI_QUIRK(0x106b, 0x2800, "MacBookPro 10,1", CS420X_MBP101),
+	SND_PCI_QUIRK(0x106b, 0x5600, "MacBookAir 5,2", CS420X_MBP81),
+	SND_PCI_QUIRK(0x106b, 0x5b00, "MacBookAir 4,2", CS420X_MBA42),
 	SND_PCI_QUIRK_VENDOR(0x106b, "Apple", CS420X_APPLE),
 	{} /* terminator */
 };
@@ -644,18 +644,18 @@ static const struct hda_model_fixup cs4208_models[] = {
 	{}
 };
 
-static const struct hda_quirk cs4208_fixup_tbl[] = {
+static const struct snd_pci_quirk cs4208_fixup_tbl[] = {
 	SND_PCI_QUIRK_VENDOR(0x106b, "Apple", CS4208_MAC_AUTO),
 	{} /* terminator */
 };
 
 /* codec SSID matching */
-static const struct hda_quirk cs4208_mac_fixup_tbl[] = {
-	HDA_CODEC_QUIRK(0x106b, 0x5e00, "MacBookPro 11,2", CS4208_MBP11),
-	HDA_CODEC_QUIRK(0x106b, 0x6c00, "MacMini 7,1", CS4208_MACMINI),
-	HDA_CODEC_QUIRK(0x106b, 0x7100, "MacBookAir 6,1", CS4208_MBA6),
-	HDA_CODEC_QUIRK(0x106b, 0x7200, "MacBookAir 6,2", CS4208_MBA6),
-	HDA_CODEC_QUIRK(0x106b, 0x7b00, "MacBookPro 12,1", CS4208_MBP11),
+static const struct snd_pci_quirk cs4208_mac_fixup_tbl[] = {
+	SND_PCI_QUIRK(0x106b, 0x5e00, "MacBookPro 11,2", CS4208_MBP11),
+	SND_PCI_QUIRK(0x106b, 0x6c00, "MacMini 7,1", CS4208_MACMINI),
+	SND_PCI_QUIRK(0x106b, 0x7100, "MacBookAir 6,1", CS4208_MBA6),
+	SND_PCI_QUIRK(0x106b, 0x7200, "MacBookAir 6,2", CS4208_MBA6),
+	SND_PCI_QUIRK(0x106b, 0x7b00, "MacBookPro 12,1", CS4208_MBP11),
 	{} /* terminator */
 };
 
@@ -834,9 +834,9 @@ static const struct hda_model_fixup cs421x_models[] = {
 	{}
 };
 
-static const struct hda_quirk cs421x_fixup_tbl[] = {
+static const struct snd_pci_quirk cs421x_fixup_tbl[] = {
 	/* Test Intel board + CDB2410  */
-	HDA_CODEC_QUIRK(0x8086, 0x5001, "DP45SG/CDB4210", CS421X_CDB4210),
+	SND_PCI_QUIRK(0x8086, 0x5001, "DP45SG/CDB4210", CS421X_CDB4210),
 	{} /* terminator */
 };
 


### PR DESCRIPTION
Looks like the snd_hda_pick_fixup function has moved from using pointers to snd_pci_quirk to using pointers to hda_quirk for its third argument. Not sure when (in terms of Kernel version) exactly this happened, must've been at some point around Kernel 6.12. This is the corresponding change: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/sound/pci/hda/hda_auto_parser.c?id=5b1913a79c3e0518d9c5db343fa9fc4edcea041f

I fixed this by moving the fixups to the new type. I have a hunch this will break older kernels though, so there's probably a better way to do this. I didn't research this whole issue much to be honest. Feel free to decline this pull request and do things the right way.

Either way, speakers work for me as they used to with this fix.