### PR TITLE
fixed dkms build

### DIFF
--- a/dkms.conf
+++ b/dkms.conf
@@ -3,7 +3,7 @@ PACKAGE_VERSION="0.1"
 PRE_BUILD="install.cirrus.driver.sh -k $kernelver"
 MAKE="make"
 BUILT_MODULE_NAME[0]="snd-hda-codec-cs420x"
-BUILT_MODULE_LOCATION[0]="build/hda"
+BUILT_MODULE_LOCATION[0]="build/hda/codecs/cirrus"
 # according to the man page this option is ignored by many distros (including Fedora and Ubuntu)
 # but is apparently still required....why??
 DEST_MODULE_LOCATION[0]="/kernel/extra"

--- a/install.cirrus.driver.sh
+++ b/install.cirrus.driver.sh
@@ -97,6 +97,9 @@ fi
 
 update_dir="/lib/modules/$(uname -r)/updates"
 [[ ! -d $update_dir ]] && mkdir $update_dir
+if ((${#dkms_kernel[@]})); then
+    cp $makefile_name Makefile
+fi
 make -f $makefile_name
 make -f $makefile_name install
 echo -e "\ncontents of $update_dir"


### PR DESCRIPTION
After #44 dkms build does not work due to expectations from dkms.conf

Corrected inconsistency to allow both dkms and classic builds.