### PR TITLE
Fix capture / mixer / init paths so MacBook9,1 mic + controls work

### DIFF
--- a/patch_cirrus/patch_cirrus_a1534_pcm.h
+++ b/patch_cirrus/patch_cirrus_a1534_pcm.h
@@ -245,7 +245,17 @@ void cs_4208_playback_pcm_hook(struct hda_pcm_stream *hinfo, struct hda_codec *c
 
 static int cs_4208_build_controls_explicit(struct hda_codec *codec)
 {
+	int retval;
 	codec_dbg(codec, "cs_4208_build_controls_explicit start");
+
+	// Without this, no capture / mic mixer controls get created, ALSA never
+	// selects an ADC for input, so the capture stream stays silent. We let
+	// the generic builder create the standard set; speaker output still goes
+	// through our custom playback PCM regardless.
+	retval = snd_hda_gen_build_controls(codec);
+	if (retval < 0)
+		return retval;
+
 	codec_dbg(codec, "cs_4208_build_controls_explicit end");
 	return 0;
 }
@@ -260,23 +270,26 @@ int cs_4208_build_pcms_explicit(struct hda_codec *codec)
 
 	codec_dbg(codec, "cs_4208_build_pcms_explicit start");
 
-	//retval =  snd_hda_gen_build_pcms(codec);
+	// Let the generic builder set up everything (including the capture stream
+	// for the internal/external mic). Without this we get no capture device
+	// at all — speakers may work but mic is dead. We then override only the
+	// analog playback stream below with the leifliddy custom config.
+	retval = snd_hda_gen_build_pcms(codec);
+	if (retval < 0)
+		return retval;
 
 	cs_4208_fill_pcm_stream_name(gen_spec->stream_name_analog,
 					sizeof(gen_spec->stream_name_analog),
 					" Analog", codec->core.chip_name);
-	info = snd_hda_codec_pcm_new(codec, "%s", gen_spec->stream_name_analog);
+	info = gen_spec->pcm_rec[0];
 	if (!info)
 		return -ENOMEM;
-	gen_spec->pcm_rec[0] = info;
 
 	info->stream[SNDRV_PCM_STREAM_PLAYBACK] = cs4208_pcm_analog_playback;
 	info->stream[SNDRV_PCM_STREAM_PLAYBACK].nid = 0x04; // 0x04 is for speakers 0x02 is for headphones
 	info->stream[SNDRV_PCM_STREAM_PLAYBACK].channels_max = 4;
 
 	info->pcm_type = HDA_PCM_TYPE_AUDIO;
-
-	retval = 0;
 
 	codec_dbg(codec, "cs_4208_build_pcms_explicit end");
 	return retval;
@@ -304,10 +317,18 @@ void cs_4208_jack_unsol_event(struct hda_codec *codec, unsigned int res)
 
 static int cs_4208_init_explicit(struct hda_codec *codec)
 {
-	//struct cs_spec *spec = codec->spec;
+	int retval;
 	codec_dbg(codec, "cs_4208_init_explicit start");
-	codec_dbg(codec, "cs_4208_init_explicit end");
 
+	// Without calling the generic init, the codec's input path (ADC mux
+	// selection, mic pin enables, capture amp defaults) never gets set up,
+	// so even with capture controls present recording stays silent.
+	// snd_hda_gen_init configures all input/output paths from the auto-config.
+	retval = snd_hda_gen_init(codec);
+	if (retval < 0)
+		return retval;
+
+	codec_dbg(codec, "cs_4208_init_explicit end");
 	return 0;
 }
 


### PR DESCRIPTION
## Summary

The speaker-amp init in `play_a1534`/`headphones_a1534` already correctly wakes the smart amp on **MacBook9,1** (A1534, 12-inch 2016 retina) — speakers actually do produce sound on this hardware. But three callbacks in `cs_4208_patch_ops_explicit` were left as stubs, which made the driver appear broken end-to-end and likely explains the symptoms reported in #27.

| Stub | Effect on MacBook9,1 |
|---|---|
| `cs_4208_build_pcms_explicit` only built playback PCM | No capture device → mic dead |
| `cs_4208_build_controls_explicit` was empty | No Master / Capture / Mic Boost / Auto-Mute mixer controls |
| `cs_4208_init_explicit` was empty | ADC mux / pin enable / capture amp never configured → silent capture even after controls present |

Each fix calls the kernel's generic helper to fill in the standard codec setup. Speaker init code (DAC 0x0a, vendor verb `0x7f0=0xae`, GPIO sequence, widget 0x24 PROC_STATE) is preserved unchanged — `build_pcms_explicit` calls `snd_hda_gen_build_pcms` first, then overrides only `pcm_rec[0]`'s playback stream with the existing custom 4-channel config.

## Verification

Tested on MacBook9,1 (A1534) running Ubuntu 24.04, kernel 6.17.0-22-generic.

**Speakers + mic both working.** Closed-loop FFT verification using the internal mic to capture a 1873 Hz tone played through internal speakers (sox-generated WAV, played via aplay):

```
baseline (silence): tone@1873Hz energy =      136 853
playing tone     : tone@1873Hz energy =   66 795 672
ratio = 488x  |  SNR = 507x
```

(Detection threshold for "speakers definitely producing sound" was set conservatively at 4x ratio + 3 SNR — actual signal blew past it by two orders of magnitude.)

`amixer -c 0 scontrols` shows full set of mixer controls back: Master, PCM, Line Out, Mic Boost, Capture, Auto-Mute Mode, Internal Mic Boost. `arecord -l` shows the capture device. PipeWire `wpctl status` shows the analog source.

## Test plan

- [x] Speakers produce audible sound on MacBook9,1
- [x] Internal mic records non-silent audio (RMS > 0)
- [x] Standard mixer controls (Master, Capture, Mic Boost) all present
- [x] FFT closed-loop verification of speaker output via mic
- [ ] Headphone jack output — not tested by reporter (didn't have a wired pair handy); should behave as before since that path wasn't touched
- [ ] Behavior on MacBook10,1 — only MacBook9,1 verified

## Notes for review

- Behavior on the MacBookPro paths (the old `cs_4208_patch_ops_dav` / generic `cs_patch_ops` codepaths) is **unchanged** — these patches only affect the explicit ops table used after `setup_a1534`/`play_a1534`, so MacBookPro users following the original davidjo path are not impacted.
- Default speaker volume on MacBook9,1 is loud — setting GNOME / `wpctl` sink volume to ~30% before first playback is recommended in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)