### PR TITLE
Add working headphone jack switching, fix HP audio, document volume setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,46 +1,177 @@
-Work in progress audio driver for the 12" MacBook that's largely based on davidjo's [snd_hda_macbookpro](https://github.com/davidjo/snd_hda_macbookpro)
+# CS4208 audio driver for the 12-inch MacBook
 
-**macbooks supported**:
-MacBook9,1 (2016) and Macbook10,1 (2017)  
-Note: the Macbook8,1 (2015) is not supported
+Out-of-tree audio driver for the **Cirrus Logic CS4208** codec in the 12-inch
+MacBook (**MacBook9,1** / 2016 and **MacBook10,1** / 2017).
 
-**Kernels supported**:
-\>= 5.0
+The mainline kernel has no working configuration for this codec on these
+machines: the codec is detected, but the speaker amplifier is never enabled, so
+the built-in speakers stay silent. This module replays the initialization the
+codec needs (reverse-engineered from macOS) and adds proper headphone/speaker
+routing on top.
 
-Compiling and installing driver:
--------------
+Based on davidjo's [snd_hda_macbookpro](https://github.com/davidjo/snd_hda_macbookpro)
+and forked from leifliddy's [macbook12-audio-driver](https://github.com/leifliddy/macbook12-audio-driver).
 
-**fedora package install**
-```
-dnf install dkms gcc kernel-devel make wget
-```
-**ubuntu package install**
-```
-apt install dkms gcc linux-headers-generic make wget
-```
-**arch package install**
-```
-pacman -S dkms gcc linux-headers make wget
-```
-1. **build and install dkms module** (experimental feature)  
-this will build the module for the current/active kernel  
-and will auto-compile this module whenever you install a newer kernel  
-```
-git clone https://github.com/leifliddy/macbook12-audio-driver.git
-cd macbook12-audio-driver/
-# run the following command as root or with sudo
-./install.cirrus.driver.sh -i
-reboot
+## What works
 
-# to uninstall the dkms feature run:
-./install.cirrus.driver.sh -u
+- Internal speakers
+- Headphone jack
+- Automatic speaker / headphone switching on plug / unplug
+- Volume control — needs one extra config step, see [Speaker volume](#3-speaker-volume-required)
+- Internal microphone
+
+## What this fork adds over upstream
+
+Upstream is **speaker-only** — the headphone path was present but commented out
+as "reserved for future use." This fork makes headphones actually work:
+
+- **Re-enables the headphone output path** (`headphones_a1534`).
+- **Routes from the live headphone-jack sense** instead of always selecting the
+  speakers.
+- **Switches a *running* stream on both plug and unplug** by handling the
+  codec's unsolicited jack interrupt — not only when a new stream opens.
+- **Fixes loud/distorted headphone audio** when plugging in during playback: the
+  headphone converter was programmed for 24-bit while the stream is 16-bit.
+
+## Supported hardware & kernels
+
+|               |                                                       |
+| ------------- | ----------------------------------------------------- |
+| Models        | MacBook9,1 (2016), MacBook10,1 (2017)                 |
+| Not supported | MacBook8,1 (2015)                                     |
+| Kernels       | ≥ 5.0 (including the 6.17+ `sound/hda/codecs` layout) |
+| Audio server  | PipeWire or PulseAudio                                 |
+
+## Installation
+
+### 1. Install build prerequisites
+
+**Ubuntu / elementary / Debian**
+```bash
+sudo apt install dkms gcc make git wget linux-headers-$(uname -r)
+```
+**Fedora**
+```bash
+sudo dnf install dkms gcc make git wget kernel-devel
+```
+**Arch**
+```bash
+sudo pacman -S dkms gcc make git wget linux-headers
 ```
 
-2. (backup method if dkms didn't work) **manually build and install module for current kernel**
+### 2. Build & install the module (DKMS — recommended)
+
+DKMS rebuilds the module automatically whenever you install a new kernel, so
+audio keeps working across kernel updates.
+
+```bash
+git clone https://github.com/breitburg/macbook12-audio-driver.git
+cd macbook12-audio-driver
+sudo ./install.cirrus.driver.sh -i
+sudo reboot
 ```
-git clone https://github.com/leifliddy/macbook12-audio-driver.git
-cd macbook12-audio-driver/
-# run the following command as root or with sudo
-./install.cirrus.driver.sh
-reboot
+
+> [!NOTE]
+> The build downloads the matching kernel source tarball to obtain the
+> HD-audio codec headers, so **an internet connection is required at build
+> time** — including when DKMS rebuilds after a kernel update.
+
+> [!IMPORTANT]
+> Keep the cloned directory in place. The DKMS install links to it, and removing
+> it will break the automatic rebuild on the next kernel update.
+
+To uninstall:
+```bash
+sudo ./install.cirrus.driver.sh -u
 ```
+
+<details>
+<summary>Manual build (fallback — does <b>not</b> survive kernel updates)</summary>
+
+```bash
+git clone https://github.com/breitburg/macbook12-audio-driver.git
+cd macbook12-audio-driver
+sudo ./install.cirrus.driver.sh
+sudo reboot
+```
+</details>
+
+### 3. Speaker volume (required)
+
+The internal speaker has **no usable hardware volume control** — the codec's only
+analog amplifier is wired to the headphone path. PipeWire therefore has to apply
+volume in software for this card. **Without this step the volume slider appears
+to do nothing on the speakers.**
+
+Check your WirePlumber version first:
+```bash
+wireplumber --version
+```
+
+**WirePlumber 0.5+** (most current distros) — create
+`/etc/wireplumber/wireplumber.conf.d/51-macbook-cs4208-softvol.conf`:
+```
+monitor.alsa.rules = [
+  {
+    matches = [ { device.name = "alsa_card.pci-0000_00_1f.3" } ]
+    actions = { update-props = { api.alsa.soft-mixer = true } }
+  }
+]
+```
+
+**WirePlumber 0.4** — create
+`/etc/wireplumber/main.lua.d/51-macbook-cs4208-softvol.lua`:
+```lua
+table.insert(alsa_monitor.rules, {
+  matches = {
+    { { "device.name", "equals", "alsa_card.pci-0000_00_1f.3" } },
+  },
+  apply_properties = {
+    ["api.alsa.soft-mixer"] = true,
+  },
+})
+```
+
+Copy-paste-ready versions of both live in [`contrib/wireplumber/`](contrib/wireplumber).
+
+Then pin the hardware amps to full, persist them, and restart WirePlumber:
+```bash
+amixer -c0 sset Master 100% unmute
+sudo alsactl store
+systemctl --user restart wireplumber
+```
+
+> [!NOTE]
+> On these MacBooks the audio controller is at PCI `00:1f.3`, which is what the
+> config matches. If yours differs, find the card name with
+> `wpctl status` or `pactl list cards short`.
+
+## Verifying
+
+```bash
+# confirm this module (not the in-tree stub) is loaded:
+modinfo snd_hda_codec_cs420x | grep filename     # should point at .../updates/...
+
+# then play a test sound and plug/unplug headphones — audio should follow:
+wpctl status
+```
+
+## How it works & limitations
+
+The CS4208 in these MacBooks drives the **speakers over a digital link**
+(converter `0x0a` → pin `0x1d`, with the amplifier enabled by a GPIO) and the
+**headphones over the analog DAC** (converter `0x02` → pin `0x10`). The module
+replays the macOS init for both paths and, on a jack interrupt, re-points the
+active stream onto the correct converter (disabling the speaker pin so it
+doesn't bleed while headphones are in).
+
+- Switching is done at the codec level and cooperates with PipeWire's own jack
+  handling.
+- Because the speaker relies on software volume, **very low headphone levels can
+  sound slightly compressed** (reduced effective bit depth). Normal listening
+  levels are unaffected.
+
+## Credits
+
+- **davidjo** — original [snd_hda_macbookpro](https://github.com/davidjo/snd_hda_macbookpro) reverse-engineering this is built on
+- **leifliddy** — [macbook12-audio-driver](https://github.com/leifliddy/macbook12-audio-driver), the base for this fork

--- a/contrib/wireplumber/main.lua.d/51-macbook-cs4208-softvol.lua
+++ b/contrib/wireplumber/main.lua.d/51-macbook-cs4208-softvol.lua
@@ -1,0 +1,22 @@
+-- MacBook9,1 / MacBook10,1 CS4208 - force software volume (WirePlumber 0.4)
+--
+-- The internal speaker has no usable hardware volume control (the codec's only
+-- analog amp is wired to the headphone path), so PipeWire must apply volume in
+-- software for this card. Without this the volume slider does nothing on the
+-- speakers. Applied at the device level so it takes effect before the card
+-- profile's mixer paths are set up.
+--
+-- Install to: /etc/wireplumber/main.lua.d/51-macbook-cs4208-softvol.lua
+-- then: systemctl --user restart wireplumber
+--
+-- If your audio controller is not at PCI 00:1f.3, adjust device.name
+-- (find it with `wpctl status` or `pactl list cards short`).
+
+table.insert(alsa_monitor.rules, {
+  matches = {
+    { { "device.name", "equals", "alsa_card.pci-0000_00_1f.3" } },
+  },
+  apply_properties = {
+    ["api.alsa.soft-mixer"] = true,
+  },
+})

--- a/contrib/wireplumber/wireplumber.conf.d/51-macbook-cs4208-softvol.conf
+++ b/contrib/wireplumber/wireplumber.conf.d/51-macbook-cs4208-softvol.conf
@@ -1,0 +1,20 @@
+# MacBook9,1 / MacBook10,1 CS4208 - force software volume (WirePlumber 0.5+)
+#
+# The internal speaker has no usable hardware volume control (the codec's only
+# analog amp is wired to the headphone path), so PipeWire must apply volume in
+# software for this card. Without this the volume slider does nothing on the
+# speakers. Applied at the device level so it takes effect before the card
+# profile's mixer paths are set up.
+#
+# Install to: /etc/wireplumber/wireplumber.conf.d/51-macbook-cs4208-softvol.conf
+# then: systemctl --user restart wireplumber
+#
+# If your audio controller is not at PCI 00:1f.3, adjust device.name
+# (find it with `wpctl status` or `pactl list cards short`).
+
+monitor.alsa.rules = [
+  {
+    matches = [ { device.name = "alsa_card.pci-0000_00_1f.3" } ]
+    actions = { update-props = { api.alsa.soft-mixer = true } }
+  }
+]

--- a/patch_cirrus/patch_cirrus_a1534_pcm.h
+++ b/patch_cirrus/patch_cirrus_a1534_pcm.h
@@ -1,3 +1,14 @@
+/* ---- CS4208 live headphone<->speaker auto-switch state ----
+ * The captured macOS sequences (play_a1534 / headphones_a1534) only get run at
+ * PCM-open time. To switch a *running* stream when the jack is plugged/unplugged
+ * we cache the live stream tag+format here and re-point the DMA stream onto the
+ * correct converter from the unsolicited jack handler below. */
+static unsigned int cs4208_cur_stream_tag;	/* running PCM stream tag (0 = none) */
+static unsigned int cs4208_cur_format;		/* running PCM HDA format word */
+static int cs4208_cur_hp = -1;			/* last HP jack state (-1 = unknown) */
+/* cs_4208_hp_jack_callback is defined further down, after get_hda_cvt_setup_4208,
+ * which it needs to invalidate the converter format cache. */
+
 static int cs_4208_playback_pcm_prepare(struct hda_pcm_stream *hinfo,
 					struct hda_codec *codec,
 					unsigned int stream_tag,
@@ -6,6 +17,8 @@ static int cs_4208_playback_pcm_prepare(struct hda_pcm_stream *hinfo,
 {
 	struct cs_spec *spec = codec->spec;
 	codec_dbg(codec, "cs_4208_playback_pcm_prepare start");
+	cs4208_cur_stream_tag = stream_tag;	/* cache for live jack re-pointing */
+	cs4208_cur_format = format;
 	snd_hda_codec_setup_stream(codec, hinfo->nid, stream_tag, 0, format);
 
 	if (spec->gen.pcm_playback_hook)
@@ -22,6 +35,7 @@ static int cs_4208_playback_pcm_cleanup(struct hda_pcm_stream *hinfo,
 {
 	//struct cs_spec *spec = codec->spec;
 	codec_dbg(codec, "cs_4208_playback_pcm_cleanup start");
+	cs4208_cur_stream_tag = 0;	/* no running stream to re-point on jack change */
 	snd_hda_codec_cleanup_stream(codec, hinfo->nid);
 	codec_dbg(codec, "cs_4208_playback_pcm_cleanup end");
 
@@ -71,15 +85,16 @@ static int cs_4208_playback_pcm_open(struct hda_pcm_stream *hinfo,
 	codec_dbg(codec, "cs_4208_playback_pcm_open start");
 	codec_dbg(codec, "playback_pcm_open nid 0x%02x rates 0x%08x formats 0x%016llx\n",hinfo->nid,hinfo->rates,hinfo->formats);
 		hp_pin = 0x10; // HP pin is Node 0x10
-		//hp_pin_sense = snd_hda_jack_detect(codec, hp_pin);
-                hp_pin_sense = 0; //HP not working at the moment, disabling for now 
-		//codec_dbg(codec, "cs_4208_playback_pcm_open hp_pin_sense: %d", hp_pin_sense);
-		//if (hp_pin_sense == 1) { // output to headphones
-			//codec_dbg(codec, "cs_4208_playback_pcm_open playing to headphones");
-			//err = headphones_a1534(codec);
-		//}  else {
-		if (hp_pin_sense == 0) { // output to speakers
-			//codec_dbg(codec, "cs_4208_playback_pcm_open playing to speakers");
+		hp_pin_sense = snd_hda_jack_detect(codec, hp_pin);
+		cs4208_cur_hp = hp_pin_sense; // keep jack-callback in sync with open-path routing
+		codec_dbg(codec, "cs_4208_playback_pcm_open hp_pin_sense: %d", hp_pin_sense);
+		if (hp_pin_sense) { // output to headphones
+			codec_dbg(codec, "cs_4208_playback_pcm_open playing to headphones");
+			hinfo->nid = 0x02; // headphone converter (DAC) -> HP pin 0x10
+			err = headphones_a1534(codec);
+		} else { // output to speakers
+			codec_dbg(codec, "cs_4208_playback_pcm_open playing to speakers");
+			hinfo->nid = 0x04; // speaker converter (DAC) -> speaker pin 0x1d
 			err = play_a1534(codec);
 		}
 	
@@ -315,6 +330,51 @@ void cs_4208_jack_unsol_event(struct hda_codec *codec, unsigned int res)
 
 #define cs_4208_free            snd_hda_gen_free
 
+/* Unsolicited HP-jack handler: re-route speaker<->headphone for a *running*
+ * stream. Defined here (not at the top) because it needs get_hda_cvt_setup_4208
+ * to invalidate the converter format cache before re-pointing the stream. */
+static void cs_4208_hp_jack_callback(struct hda_codec *codec,
+				     struct hda_jack_callback *cb)
+{
+	struct hda_cvt_setup *p;
+	int hp = snd_hda_jack_detect(codec, 0x10);
+
+	codec_dbg(codec, "cs_4208_hp_jack_callback hp=%d (prev=%d) tag=%u",
+		  hp, cs4208_cur_hp, cs4208_cur_stream_tag);
+	if (hp == cs4208_cur_hp)
+		return;
+	cs4208_cur_hp = hp;
+
+	if (hp) {				/* headphones plugged */
+		headphones_a1534(codec);
+		if (cs4208_cur_stream_tag) {
+			/* Invalidate the cached converter setup so setup_stream
+			 * actually reprograms the live format - otherwise 0x02
+			 * keeps headphones_a1534()'s hardcoded format and plays
+			 * loud garbage until PipeWire's own reopen fixes it. */
+			p = get_hda_cvt_setup_4208(codec, 0x02);
+			p->stream_tag = 0; p->channel_id = 0; p->format_id = 0;
+			snd_hda_codec_setup_stream(codec, 0x02,
+						   cs4208_cur_stream_tag, 0,
+						   cs4208_cur_format);
+		}
+		/* Silence the speaker by disabling its output pin (0x1d) without
+		 * touching the converters/stream the headphones now use.
+		 * play_a1534() re-enables 0x1d on the way back to speakers. */
+		snd_hda_codec_write(codec, 0x1d, 0,
+				    AC_VERB_SET_PIN_WIDGET_CONTROL, 0x00);
+	} else {				/* back to speakers */
+		play_a1534(codec);
+		if (cs4208_cur_stream_tag) {
+			p = get_hda_cvt_setup_4208(codec, 0x04);
+			p->stream_tag = 0; p->channel_id = 0; p->format_id = 0;
+			snd_hda_codec_setup_stream(codec, 0x04,
+						   cs4208_cur_stream_tag, 0,
+						   cs4208_cur_format);
+		}
+	}
+}
+
 static int cs_4208_init_explicit(struct hda_codec *codec)
 {
 	int retval;
@@ -327,6 +387,11 @@ static int cs_4208_init_explicit(struct hda_codec *codec)
 	retval = snd_hda_gen_init(codec);
 	if (retval < 0)
 		return retval;
+
+	/* Enable live speaker<->headphone switching: fire cs_4208_hp_jack_callback
+	 * on every plug/unplug interrupt from the HP pin (0x10). */
+	cs4208_cur_hp = -1;
+	snd_hda_jack_detect_enable_callback(codec, 0x10, cs_4208_hp_jack_callback);
 
 	codec_dbg(codec, "cs_4208_init_explicit end");
 	return 0;
@@ -343,7 +408,7 @@ static const struct hda_codec_ops cs_4208_patch_ops_explicit = {
 	.build_pcms = cs_4208_build_pcms_explicit,
 	.init = cs_4208_init_explicit,
 	.free = cs_4208_free_explicit,
-	//.unsol_event = snd_hda_jack_unsol_event, //cs_4208_jack_unsol_event,
+	.unsol_event = snd_hda_jack_unsol_event,
 //#ifdef UNDEF_CONFIG_PM
 //      .suspend = cs_4208_suspend,
 //      .resume = cs_4208_resume,

--- a/patch_cirrus/patch_cirrus_a1534_setup.h
+++ b/patch_cirrus/patch_cirrus_a1534_setup.h
@@ -96,7 +96,7 @@ void snd_hda_coef_item(struct hda_codec *codec, u16 write_flag, hda_nid_t nid, u
         }
 }
 
-/* reserved for future use
+/* re-enabled: headphone output path, called on jack-detect from pcm_open */
 static int headphones_a1534 (struct hda_codec *codec) {
 	int retval;
 	codec_dbg(codec, "headphones_a1534 start");
@@ -300,7 +300,7 @@ static int headphones_a1534 (struct hda_codec *codec) {
  //       { 1, CS4208_VENDOR_NID, 0x0035, 0x0000, 0x00000000 }, //   coef write 168
         snd_hda_coef_item(codec, 1, CS4208_VENDOR_NID, 0x0035, 0x0000, 0x00000000, 169 ); //   coef write 169
 
-        snd_hda_codec_write(codec, 0x02, 0, AC_VERB_SET_STREAM_FORMAT, 0x00004031); // 0x00224031
+        snd_hda_codec_write(codec, 0x02, 0, AC_VERB_SET_STREAM_FORMAT, 0x00004011); // was 0x4031 (24-bit): forced to 0x4011 (16-bit) to match Linux S16_LE stream
 //       snd_hda:     stream format 2 [('CHAN', 2), ('RATE', 44100), ('BITS', 24), ('RATE_MUL', 1), ('RATE_DIV', 1)]
 
         retval = snd_hda_codec_read_check(codec, 0x02, 0, AC_VERB_GET_POWER_STATE, 0x00000000, 0x00000033, 174); // 0x002f0500
@@ -387,7 +387,7 @@ static int headphones_a1534 (struct hda_codec *codec) {
  //       { 1, CS4208_VENDOR_NID, 0x0035, 0x0000, 0x00000000 }, //   coef write 210
         snd_hda_coef_item(codec, 1, CS4208_VENDOR_NID, 0x0035, 0x0000, 0x00000000, 211 ); //   coef write 211
 
-        snd_hda_codec_write(codec, 0x02, 0, AC_VERB_SET_STREAM_FORMAT, 0x00004031); // 0x00224031
+        snd_hda_codec_write(codec, 0x02, 0, AC_VERB_SET_STREAM_FORMAT, 0x00004011); // was 0x4031 (24-bit): forced to 0x4011 (16-bit) to match Linux S16_LE stream
 //       snd_hda:     stream format 2 [('CHAN', 2), ('RATE', 44100), ('BITS', 24), ('RATE_MUL', 1), ('RATE_DIV', 1)]
 
 
@@ -499,7 +499,7 @@ static int headphones_a1534 (struct hda_codec *codec) {
  //       { 1, CS4208_VENDOR_NID, 0x0035, 0x0000, 0x00000000 }, //   coef write 292
         snd_hda_coef_item(codec, 1, CS4208_VENDOR_NID, 0x0035, 0x0000, 0x00000000, 293 ); //   coef write 293
 
-        snd_hda_codec_write(codec, 0x02, 0, AC_VERB_SET_STREAM_FORMAT, 0x00004031); // 0x00224031
+        snd_hda_codec_write(codec, 0x02, 0, AC_VERB_SET_STREAM_FORMAT, 0x00004011); // was 0x4031 (24-bit): forced to 0x4011 (16-bit) to match Linux S16_LE stream
 //       snd_hda:     stream format 2 [('CHAN', 2), ('RATE', 44100), ('BITS', 24), ('RATE_MUL', 1), ('RATE_DIV', 1)]
 
         retval = snd_hda_codec_read_check(codec, 0x02, 0, AC_VERB_GET_POWER_STATE, 0x00000000, 0x00000030, 298); // 0x002f0500
@@ -619,7 +619,6 @@ static int headphones_a1534 (struct hda_codec *codec) {
 	codec_dbg(codec, "headphones_a1534 end");
 	return 0;
 }
-*/
 
 static int setup_a1534 (struct hda_codec *codec) {
 	int retval;


### PR DESCRIPTION
Enables proper speaker <-> headphone handling on the 12" MacBook (MacBook9,1 / MacBook10,1) CS4208 codec, which was previously speaker-only (the headphone path, headphones_a1534, was left entirely inside a block comment).

Driver changes:
- Re-enable headphones_a1534() (was "reserved for future use").
- Drive routing from the live headphone-jack sense in cs_4208_playback_pcm_open() instead of hardcoding speakers.
- Handle the codec's unsolicited HP-jack interrupt (cs_4208_hp_jack_callback) so a *running* stream switches on both plug and unplug, not only when a new stream opens. The handler re-points the live DMA stream to the correct converter (0x02 headphones / 0x04 speakers), invalidating the converter format cache first, and disables the speaker pin (0x1d) on plug-in to stop speaker bleed.
- Fix loud/distorted headphones when plugging in mid-playback: headphones_a1534() programmed converter 0x02 for 24-bit (0x4031) but the ALSA stream is S16_LE, so the converter misread the data until a full reopen. Program 16-bit (0x4011) to match the only format the PCM advertises.

Docs:
- Rewrite README to describe current capabilities and best-practice install.
- Document the required WirePlumber api.alsa.soft-mixer setting (the speaker has no usable hardware volume control) and ship ready-to-use config files for WirePlumber 0.4 and 0.5 under contrib/wireplumber/.

Tested on MacBook10,1 (2017), kernel 6.17, elementary OS 8 / PipeWire 1.0.