### PR TITLE
Fix failed re-probe after cs4208_probe() swaps the driver ops

### DIFF
--- a/patch_cirrus/cs420x.c
+++ b/patch_cirrus/cs420x.c
@@ -721,6 +721,8 @@ static void cs4208_fix_amp_caps(struct hda_codec *codec, hda_nid_t adc)
 	snd_hda_override_amp_caps(codec, adc, HDA_INPUT, caps);
 }
 
+static const struct hda_codec_ops cs_4208_codec_ops;
+
 static int cs4208_probe(struct hda_codec *codec)
 {
 	struct cs_spec *spec = codec->spec;
@@ -732,7 +734,7 @@ static int cs4208_probe(struct hda_codec *codec)
 	//mb9-specific
 	err = setup_a1534(codec);
 	err = play_a1534(codec);
-	hda_codec_to_driver(codec)->ops = &cs_4208_patch_ops_explicit;
+	hda_codec_to_driver(codec)->ops = &cs_4208_codec_ops;
 	spec->gen.pcm_playback_hook = cs_4208_playback_pcm_hook;
 	//end
 
@@ -783,6 +785,20 @@ static const struct hda_codec_ops cs_codec_ops = {
 	.init = cs_init,
 	.unsol_event = snd_hda_jack_unsol_event,
 	.stream_pm = snd_hda_gen_stream_pm,
+};
+
+/* cs4208_probe() points the shared driver ops here, so this table must keep
+ * .probe and .remove: without them every codec re-probe after the first
+ * (reconfig, unbind/rebind) fails in hda_codec_driver_probe() with -EINVAL. */
+static const struct hda_codec_ops cs_4208_codec_ops = {
+	.probe = cs_codec_probe,
+	.remove = cs_4208_free_explicit,
+	.build_controls = cs_4208_build_controls_explicit,
+	.build_pcms = cs_4208_build_pcms_explicit,
+	.init = cs_4208_init_explicit,
+	.unsol_event = snd_hda_jack_unsol_event,
+	.stream_pm = snd_hda_gen_stream_pm,
+	.resume = cs_4208_resume,
 };
 
 /*


### PR DESCRIPTION
## Bug

`cs4208_probe()` points the shared, driver-wide ops at `cs_4208_patch_ops_explicit`:

```c
hda_codec_to_driver(codec)->ops = &cs_4208_patch_ops_explicit;
```

That table has no `.probe`, so after the first successful probe the driver can never probe again. Any codec re-probe — `echo 1 > /sys/.../reconfig`, or unbind/rebind through sysfs — fails:

```
!(driver->ops && driver->ops->probe)
WARNING: sound/hda/common/bind.c:115 at hda_codec_driver_probe+0x174/0x1d0 [snd_hda_codec]
snd_hda_codec_cs420x hdaudioC0D0: probe with driver snd_hda_codec_cs420x failed with error -22
```

leaving the codec unbound (no sound at all) until the module is reloaded. Reproduced on a MacBook10,1 running kernel 7.1.8 (new `sound/hda/codecs` layout); normal boot is unaffected since the first probe uses the original ops.

## Fix

Add a complete new-layout ops table `cs_4208_codec_ops` in `cs420x.c` — the explicit A1534 callbacks plus `.probe`/`.remove` — and install that instead. The shared `patch_cirrus_a1534_pcm.h` table is untouched, so the old-layout `patch_cirrus.c` build (which uses per-codec `patch_ops` and has no such bug) is unaffected, as is the `prepare` script's `.free` → `.remove` rewrite.

## Testing

- Builds clean for 7.1.8 (new layout) via the standard prepare + make flow.
- The bug itself (WARNING + `-22` on rebind) reproduced on MacBook10,1 hardware with current master.
- Runtime verification of the patched module on hardware is still pending — flagging that honestly; the change is confined to which static table the existing assignment points at.