### PR TITLE
Increase max number of input pins to 22

### DIFF
--- a/prepare.cirrus.driver.sh
+++ b/prepare.cirrus.driver.sh
@@ -122,6 +122,7 @@ if (( major_version > 6 || (major_version == 6 && minor_version >= 17) )); then
     "$patch_dir/patch_cirrus_a1534_pcm.h" \
     "$hda_dir/codecs/cirrus"
   cp "$patch_dir/$makefile_name" "$hda_dir/codecs/cirrus/Makefile"
+  sed -i 's/#define AUTO_CFG_MAX_INS\t[0-9]\{1,2\}/#define AUTO_CFG_MAX_INS\t22/' "$hda_dir/common/hda_auto_parser.h"
 else
   makefile_name="Makefile_cirrus"
   tar --strip-components=3 -xf "$archive" --directory="$build_dir" \
@@ -133,6 +134,7 @@ else
     "$patch_dir/patch_cirrus_a1534_pcm.h" \
     "$hda_dir"
   cp "$patch_dir/$makefile_name" "$hda_dir/Makefile"
+  sed -i 's/#define AUTO_CFG_MAX_INS\t[0-9]\{1,2\}/#define AUTO_CFG_MAX_INS\t22/' "$hda_dir/hda_auto_parser.h"
 fi
 
 if (( major_version > 6 || (major_version == 6 && minor_version >= 17) )); then


### PR DESCRIPTION
Driver crashing on Ubuntu 26.04 Kernel 7.0.

The driver compiles correctly but when loaded, the input pin auto config reports 22 pins but the maximum allowable number is 18 causing an out of bounds stack trace upon access when UBSAN (UndefinedBehaviorSanitizer) is enabled like in Ubuntu 26.04.

Patch modifies hda_auto_parser.h to increase AUTO_CFG_MAX_INS to 22 to allow for the additional pins. AUTO_CFG_MAX_INS is 8 for kernel 5.0 - 5.12, and 18 for kernel 5.13+. The sed edit will work for either value and allows driver to load.

Example error before modification:
------------[ cut here ]------------
UBSAN: array-index-out-of-bounds in /build/linux-zi5WOl/linux-7.0.0/sound/hda/codecs/generic.c:1510:24
index 21 is out of range for type 'auto_pin_cfg_item [18]'
CPU: 3 UID: 0 PID: 1300 Comm: modprobe Tainted: G OE 7.0.0-29-generic #29-Ubuntu PREEMPT(lazy)
Tainted: [O]=OOT_MODULE, [E]=UNSIGNED_MODULE
Hardware name: Apple Inc. MacBook10,1/Mac-EE2EBD4B90B839A8, BIOS 529.140.2.0.0 06/23/2024
Call Trace:
show_stack+0x49/0x60
dump_stack_lvl+0x5f/0x90
dump_stack+0x10/0x18
ubsan_epilogue+0x9/0x39
etc.