### PR TITLE
Support deb based kernel source for ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Based on davidjo's [snd_hda_macbookpro](https://github.com/davidjo/snd_hda_macbo
 
 **Ubuntu / elementary / Debian**
 ```bash
-sudo apt install curl dkms gcc make git linux-headers-$(uname -r)
+sudo apt install curl dkms gcc make git linux-headers-$(uname -r) linux-source-$(uname -r)
 ```
 **Fedora**
 ```bash

--- a/prepare.cirrus.driver.sh
+++ b/prepare.cirrus.driver.sh
@@ -62,53 +62,93 @@ checksum_for() {
 mkdir -p "$build_dir" "$cache_dir"
 rm -rf "$hda_dir"
 
-checksums="$cache_dir/sha256sums-v${major_version}.asc"
-[[ -f $checksums ]] || refresh_checksums
+# Debian/Ubuntu Kernel logic adapted from https://github.com/davidjo/snd_hda_macbookpro/blob/master/install.cirrus.driver.sh
+is_debian_like=0
+# Check if we are dealing with Debian
+if [[ $(grep '^NAME=' /etc/os-release | grep -c Debian) -eq 1 ]]; then
+  is_debian_like=1
+# Check if we are dealing with Ubuntu
+elif [[ $(grep '^NAME=' /etc/os-release | grep -c Ubuntu) -eq 1 ]]; then
+  is_debian_like=1
+# For Unbuntu based distributions like Mint, ubuntu will be mentionned in ID_LIKE
+elif [[ $(grep '^ID_LIKE=' /etc/os-release | grep -c "ubuntu") -eq 1 ]]; then
+  is_debian_like=1
+# In some other Unbuntu based distributions like Pop OS, we need to check ID
+elif [ $(grep '^ID=' /etc/os-release | grep -c "ubuntu") -eq 1 ]; then
+  is_debian_like=1
+fi
 
-archive=""
-for candidate_version in "$kernel_version" "$kernel_short_version"; do
-  archive_name="linux-${candidate_version}.tar.xz"
-  expected_sha256="$(checksum_for "$archive_name")"
+if [ $is_debian_like -ge 1 ]; then
+  # NOTE for Ubuntu we need to use the distribution kernel sources as they seem
+  # to be significantly modified from the mainline kernel sources generally with backports from later kernels
+  # NOTE this will likely NOT work for Ubuntu hwe kernels which are even more highly
+  # modified with extensive backports from later kernel versions
+  # (and in any case there is no linux-source-... package for hwe kernels)
 
-  if [[ -z $expected_sha256 ]]; then
-    refresh_checksums
-    expected_sha256="$(checksum_for "$archive_name")"
-  fi
-  [[ -n $expected_sha256 ]] || continue
-
-  candidate_archive="$cache_dir/$archive_name"
-  if [[ -f $candidate_archive ]]; then
-    actual_sha256="$(sha256sum "$candidate_archive" | awk '{ print $1 }')"
+  if [ -e /usr/src/linux-source-$kernel_version.tar.bz2 ]; then
+    comp_type='bz2' # Ubuntu packages provide bz2 compression
+  elif [ -e /usr/src/linux-source-$kernel_version.tar.xz ]; then
+    comp_type='xz'  # Debian packages provde xz compression
   else
-    actual_sha256=""
+    echo "Linux kernel source not found in /usr/src: /usr/src/linux-source-$kernel_version.tar.bz2"
+    echo "assuming the linux kernel source package is not installed"
+    echo "please install the linux kernel source package:"
+    echo "sudo apt install linux-source-$kernel_version"
+    echo "if the above doesn't work because some distros don't use LTS Kernel, download the linux-source-$kernel_version .deb file"
+    echo "using Archive Manager, Open data.tar.zst, extract /usr/src/linux-source-$kernel_version.tar.bz2"
+    echo "NOTE - This does not work for HWE kernels"
+    exit 1
   fi
+  archive="/usr/src/linux-source-${kernel_version}.tar.${comp_type}"
+  kernel_version="source-$kernel_version"
+else
+  checksums="$cache_dir/sha256sums-v${major_version}.asc"
+  [[ -f $checksums ]] || refresh_checksums
+  archive=""
+  for candidate_version in "$kernel_version" "$kernel_short_version"; do
+    archive_name="linux-${candidate_version}.tar.xz"
+    expected_sha256="$(checksum_for "$archive_name")"
 
-  if [[ $actual_sha256 != "$expected_sha256" ]]; then
-    partial_archive="$candidate_archive.part"
-    rm -f "$partial_archive"
-    echo "Downloading $archive_name"
-    if ! download "$base_url/$archive_name" "$partial_archive"; then
-      rm -f "$partial_archive"
-      continue
+    if [[ -z $expected_sha256 ]]; then
+      refresh_checksums
+      expected_sha256="$(checksum_for "$archive_name")"
+    fi
+    [[ -n $expected_sha256 ]] || continue
+
+    candidate_archive="$cache_dir/$archive_name"
+    if [[ -f $candidate_archive ]]; then
+      actual_sha256="$(sha256sum "$candidate_archive" | awk '{ print $1 }')"
+    else
+      actual_sha256=""
     fi
 
-    actual_sha256="$(sha256sum "$partial_archive" | awk '{ print $1 }')"
     if [[ $actual_sha256 != "$expected_sha256" ]]; then
+      partial_archive="$candidate_archive.part"
       rm -f "$partial_archive"
-      echo "SHA-256 verification failed for $archive_name" >&2
-      exit 3
+      echo "Downloading $archive_name"
+      if ! download "$base_url/$archive_name" "$partial_archive"; then
+        rm -f "$partial_archive"
+        continue
+      fi
+
+      actual_sha256="$(sha256sum "$partial_archive" | awk '{ print $1 }')"
+      if [[ $actual_sha256 != "$expected_sha256" ]]; then
+        rm -f "$partial_archive"
+        echo "SHA-256 verification failed for $archive_name" >&2
+        exit 3
+      fi
+      mv "$partial_archive" "$candidate_archive"
     fi
-    mv "$partial_archive" "$candidate_archive"
+
+    archive="$candidate_archive"
+    kernel_version="$candidate_version"
+    break
+  done
+
+  if [[ -z $archive ]]; then
+    echo "No verified kernel.org source archive found for $kernel_release" >&2
+    exit 4
   fi
-
-  archive="$candidate_archive"
-  kernel_version="$candidate_version"
-  break
-done
-
-if [[ -z $archive ]]; then
-  echo "No verified kernel.org source archive found for $kernel_release" >&2
-  exit 4
 fi
 
 if (( major_version > 6 || (major_version == 6 && minor_version >= 17) )); then


### PR DESCRIPTION
**Ubuntu/Debian Long Term Support (LTS) Kernel Support Issue** 
LTS kernels typically backport updates and security fixes from later kernel versions but continue to report their kernel base version number.  This is done to provide a stable kernel version with the benefit of upstream fixes.  However issues can occur when pulling the source from the mainline kernel archive based on the base kernel number, which result in a mismatched kernel source resulting in module execution errors.

**Current Ubuntu 26.04 Issues**
Starting with Ubuntu kernel version `7.0.0-29`, the kernel is including patches from 7.0.10 or later that alter the `struct hda_gen_spec` to disagree with the mainline `7.0` source tarball downloaded by the installation script.  As a result, multiple UBSAN out-of-bound errors occur when attempting to probe the sound card which causes the system to hang.

```
UBSAN: array-index-out-of-bounds in /build/linux-zi5WOl/linux-7.0.0/sound/hda/codecs/generic.c:1507:19
index 18 is out of range for type 'auto_pin_cfg_item [18]'
UBSAN: array-index-out-of-bounds in /build/linux-zi5WOl/linux-7.0.0/sound/hda/codecs/generic.c:1510:24
index 21 is out of range for type 'auto_pin_cfg_item [18]'
UBSAN: array-index-out-of-bounds in /build/linux-zi5WOl/linux-7.0.0/sound/hda/codecs/generic.c:3294:30
index 18 is out of range for type 'auto_pin_cfg_item [18]'
UBSAN: array-index-out-of-bounds in /build/linux-zi5WOl/linux-7.0.0/sound/hda/codecs/generic.c:3340:20
index 18 is out of range for type 'auto_pin_cfg_item [18]'
``` 

**Solution/Workaround**
Based on the solution used by [snd_hda_macbook install script](https://github.com/davidjo/snd_hda_macbookpro/blob/master/install.cirrus.driver.sh) Ubuntu/Debian users will be required to install the `linux-source` package which provides a tarball of the current kernel code at /usr/src/linux-source-x.x.x.tar.bz2.  This package is updated with each new kernel revision and allows proper compilation and installation.  

This pull request searches `/etc/os-release` for strings referring to Debian/Ubuntu and if they are found it tests for the existence of the kernel source tarball.  If the kernel source tarball is not found, compilation halts and the user is instructed to download the linux-source package.  If the system is not determined to Debian/Ubuntu, then the usual kernel.org sources are used.

**Notes on Ubuntu LTS Timing**
On August 27, the first point release for Ubuntu 26.04 (26.04.1 LTS) ("Resolute Raccoon") will be released.  With this release, standard users will be able to perform direct upgrades from the previous long-term support release (Ubuntu 24.04 LTS).  The kernel shipped with this release (7.0.0-30) will not compile correctly without support for the `linux-source` package.